### PR TITLE
Fixed secure hooking of tooltip

### DIFF
--- a/TheoryCraftClassicMain.lua
+++ b/TheoryCraftClassicMain.lua
@@ -549,19 +549,28 @@ function TheoryCraft_OnEvent(self, event)
 		end
 
 		-- Hooking Nurfed Action Bars onUpdate event for button text purposes
-		TheoryCraft_Data["oldGBMSB"] = GB_Spellbook_UpdatePage
-		GB_Spellbook_UpdatePage = TheoryCraft_GB_Spellbook_UpdatePage
 
-		TheoryCraft_Data["oldNurfed"] = Nurfed_ActionButton_OnUpdate
-		Nurfed_ActionButton_OnUpdate = TheoryCraft_Nurfed_ActionButton_OnUpdate
+        if GB_Spellbook_UpdatePage and TheoryCraft_GB_Spellbook_UpdatePage and not TheoryCraft_Data["oldGBMSB"] then
+            TheoryCraft_Data["oldGBMSB"] = GB_Spellbook_UpdatePage
+            GB_Spellbook_UpdatePage = TheoryCraft_GB_Spellbook_UpdatePage
+        end
+
+        if Nurfed_ActionButton_OnUpdate and TheoryCraft_Nurfed_ActionButton_OnUpdate and not TheoryCraft_Data["oldNurfed"] then
+            TheoryCraft_Data["oldNurfed"] = Nurfed_ActionButton_OnUpdate
+            Nurfed_ActionButton_OnUpdate = TheoryCraft_Nurfed_ActionButton_OnUpdate
+        end
 
 		if TheoryCraft_OnShow_Save ~= nil then
 			return
 		end
 
 		--hooking GameTooltip's OnShow
-		TheoryCraft_OnShow_Save = GameTooltip:GetScript("OnShow")
-		GameTooltip:SetScript( "OnShow", TheoryCraft_OnShow )
+        
+		--TheoryCraft_OnShow_Save = GameTooltip:GetScript("OnShow")
+		--GameTooltip:SetScript( "OnShow", TheoryCraft_OnShow )
+        hooksecurefunc(GameTooltip, "Show", TheoryCraft_OnShow)
+        TheoryCraft_OnShow_Save = true
+        
 		if TheoryCraft_Mitigation == nil then
 			TheoryCraft_Mitigation = {}
 		end

--- a/TheoryCraftClassicMessy.lua
+++ b/TheoryCraftClassicMessy.lua
@@ -424,8 +424,8 @@ function TheoryCraft_getMinMax(spelldata, returndata, frame)
 		minDamage = findpattern(minDamage, "%d+")
 		maxDamage = findpattern(maxDamage, "%d+")
 		local lengthofdamagetext = string.len(minDamage..to..maxDamage);
-		minDamage = minDamage*baseincrease + plusdam
-		maxDamage = maxDamage*baseincrease + plusdam
+		minDamage = tonumber(minDamage)*baseincrease + plusdam
+		maxDamage = tonumber(maxDamage)*baseincrease + plusdam
 
 		local minHeal = string.sub(description, string.find(description, "%d+"..to.."%d+")+lengthofdamagetext)
 		minHeal = findpattern(minHeal, "%d+"..to.."%d+")
@@ -436,8 +436,8 @@ function TheoryCraft_getMinMax(spelldata, returndata, frame)
 		local plusheal = (TheoryCraft_GetStat("All") + TheoryCraft_GetStat("Holy") + TheoryCraft_GetStat("Healing"))*spelldata.percentheal
 
 		local lengthofhealtext = string.len(minHeal..to..maxHeal);
-		minHeal = (minHeal + plusheal)*basehealincrease
-		maxHeal = (maxHeal + plusheal)*basehealincrease
+		minHeal = ((tonumber(minHeal) or 0) + plusheal)*basehealincrease
+		maxHeal = ((tonumber(maxHeal) or 0) + plusheal)*basehealincrease
 
 		description = 	string.sub(description, 0, string.find(description, "%d+"..to.."%d+", 0)-1)..
 				round(minDamage)..to..round(maxDamage)..

--- a/TheoryCraftClassicTooltip.lua
+++ b/TheoryCraftClassicTooltip.lua
@@ -20,11 +20,32 @@ local a = TheoryCraft_TooltipOrs
 local leftline, rightline, rightlinewasnil, _, doheal, timer
 local returnvalue, colour
 
+local function docolour(r, g, b)
+    r = tonumber(r)
+    g = tonumber(g)
+    b = tonumber(b)
+    if (not r) or (not g) or (not b) then return "invalid colour" end
+    if (r > 1) or (r < 0) or (g > 1) or (g < 0) or (b > 1) or (b < 0) then return "invalid colour" end
+    if first then
+        red = r
+        green = g
+        blue = b
+        first = false
+        return ""
+    else
+        return "|c"..string.format("%.2x", math.floor(r*255))..
+                string.format("%.2x", math.floor(g*255))..
+                string.format("%.2x", math.floor(b*255)).."ff"
+    end
+end
+
+local shouldSetSpell = false
+
 function TheoryCraft_AddTooltipInfo(frame, dontshow)
 	if TheoryCraft_Settings["off"] then return frame end
 	local tooltipdata = TheoryCraft_GetSpellDataByFrame(frame, true)
 	if tooltipdata == nil then
-		if (frame:NumLines() == 1) and (getglobal(frame:GetName().."TextLeft1"):GetText() ~= "Attack") then
+		if (shouldSetSpell) and (frame:NumLines() == 1) and (getglobal(frame:GetName().."TextLeft1"):GetText() ~= "Attack") then
 			local _, _, name, rank = strfind(getglobal(frame:GetName().."TextLeft1"):GetText(), "(.+)%((%d+)%)")
 			if not name then return nil end
 			rank = tonumber(rank)
@@ -43,31 +64,12 @@ function TheoryCraft_AddTooltipInfo(frame, dontshow)
 				i2 = i2 + 1
 			end
 		end
-		frame:Show()
+		--frame:Show()
 		return frame
 	end
 
 	timer = GetTime()
 	doheal = (tooltipdata["minheal"]) and (((tooltipdata["drain"] == nil) and (tooltipdata["holynova"] == nil)) or (TheoryCraft_Settings["healanddamage"]))
-
-	local function docolour(r, g, b)
-		r = tonumber(r)
-		g = tonumber(g)
-		b = tonumber(b)
-		if (not r) or (not g) or (not b) then return "invalid colour" end
-		if (r > 1) or (r < 0) or (g > 1) or (g < 0) or (b > 1) or (b < 0) then return "invalid colour" end
-		if first then
-			red = r
-			green = g
-			blue = b
-			first = false
-			return ""
-		else
-			return "|c"..string.format("%.2x", math.floor(r*255))..
-				    string.format("%.2x", math.floor(g*255))..
-				    string.format("%.2x", math.floor(b*255)).."ff"
-		end
-	end
 
 	local function dowork(n)
 		local _, _, n2 = strfind(n, "|(.+)|")
@@ -278,6 +280,6 @@ function TheoryCraft_AddTooltipInfo(frame, dontshow)
 			end
 		end
 	end
-	frame:Show()
+	-- frame:Show()
 	return frame
 end


### PR DESCRIPTION
Has side effects, but should have been done earlier.
Unsure how Theorycraft originally worked, but the whole way of using the GameTooltip to both extract information and put in the new one at the same time is not very good.
If extraction of information is needed, do that on a separate, addon-specific GameTooltip frame.