### PR TITLE
add missing argument to the event handler

### DIFF
--- a/TheoryCraftClassic.xml
+++ b/TheoryCraftClassic.xml
@@ -429,7 +429,7 @@
 				TheoryCraft_OnLoad(self)
 			</OnLoad>
 			<OnEvent>
-				TheoryCraft_OnEvent(self,event)
+				TheoryCraft_OnEvent(self,event,...)
 			</OnEvent>
 		</Scripts>
 		<Frames>

--- a/TheoryCraftClassicMain.lua
+++ b/TheoryCraftClassicMain.lua
@@ -525,7 +525,7 @@ end
 		BActionButton.Create = TheoryCraft_BActionButtonCreate
 	end
 
-function TheoryCraft_OnEvent(self, event)
+function TheoryCraft_OnEvent(self, event, arg1)
 	local UIMem = gcinfo()
 	if event == "VARIABLES_LOADED" then
 		if TheoryCraft_AddButtonText then TheoryCraft_AddButtonText() end


### PR DESCRIPTION
this should fix the tooltip not updating on events like buffs or equipment change.